### PR TITLE
Allowing for multiple Lambdas in a bucket notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-bucket-notification-module?ref=0.0.5
+github.com/pbs/terraform-aws-bucket-notification-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "bucket_notification" {
-  source = "github.com/pbs/terraform-aws-bucket-notification-module?ref=0.0.5"
+  source = "github.com/pbs/terraform-aws-bucket-notification-module?ref=x.y.z"
 
   # Required Parameters
   bucket     = module.s3.name
@@ -46,7 +46,7 @@ module "bucket_notification" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.5`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -79,7 +79,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_lambda_permission.allow_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 
 ## Inputs
@@ -87,10 +86,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | Bucket to attach notifications to | `string` | n/a | yes |
-| <a name="input_lambda_arn"></a> [lambda\_arn](#input\_lambda\_arn) | ARN of the lambda to invoke | `string` | n/a | yes |
-| <a name="input_events"></a> [events](#input\_events) | Event to notify on | `list(string)` | <pre>[<br>  "s3:ObjectCreated:*"<br>]</pre> | no |
-| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Prefix this notification should apply to | `string` | `null` | no |
-| <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Suffix this notification should apply to | `string` | `null` | no |
+| <a name="input_lambda_function_configurations"></a> [lambda\_function\_configurations](#input\_lambda\_function\_configurations) | List of lambda function configurations | <pre>list(object({<br>    id            = optional(string)<br>    lambda_arn    = string<br>    events        = list(string)<br>    filter_prefix = optional(string)<br>    filter_suffix = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  bucket_arn = "arn:aws:s3:::${var.bucket}"
-}

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,14 @@
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = var.bucket
 
-  lambda_function {
-    lambda_function_arn = var.lambda_arn
-    events              = var.events
-    filter_prefix       = var.filter_prefix
-    filter_suffix       = var.filter_suffix
+  dynamic "lambda_function" {
+    for_each = var.lambda_function_configurations
+    content {
+      id                  = lambda_function.value.id
+      lambda_function_arn = lambda_function.value.lambda_arn
+      events              = lambda_function.value.events
+      filter_prefix       = lambda_function.value.filter_prefix
+      filter_suffix       = lambda_function.value.filter_suffix
+    }
   }
 }

--- a/optional.tf
+++ b/optional.tf
@@ -1,17 +1,10 @@
-variable "events" {
-  description = "Event to notify on"
-  default     = ["s3:ObjectCreated:*"]
-  type        = list(string)
-}
-
-variable "filter_prefix" {
-  description = "Prefix this notification should apply to"
-  default     = null
-  type        = string
-}
-
-variable "filter_suffix" {
-  description = "Suffix this notification should apply to"
-  default     = null
-  type        = string
+variable "lambda_function_configurations" {
+  description = "List of lambda function configurations"
+  type = list(object({
+    id            = optional(string)
+    lambda_arn    = string
+    events        = list(string)
+    filter_prefix = optional(string)
+    filter_suffix = optional(string)
+  }))
 }

--- a/required.tf
+++ b/required.tf
@@ -2,8 +2,3 @@ variable "bucket" {
   description = "Bucket to attach notifications to"
   type        = string
 }
-
-variable "lambda_arn" {
-  description = "ARN of the lambda to invoke"
-  type        = string
-}

--- a/security.tf
+++ b/security.tf
@@ -1,7 +1,0 @@
-resource "aws_lambda_permission" "allow_bucket" {
-  statement_id  = "AllowExecutionFromS3Bucket"
-  action        = "lambda:InvokeFunction"
-  function_name = var.lambda_arn
-  principal     = "s3.amazonaws.com"
-  source_arn    = local.bucket_arn
-}


### PR DESCRIPTION
This is a breaking change because the interface for the module is being adjusted to use an object of `lambda_function_configurations` instead of a single instance of the relevant variables.

Closes #4 